### PR TITLE
Add basic PWA support for Android installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="theme-color" content="#0a7bff" />
+    <link rel="manifest" href="/manifest.webmanifest" />
   </head>
 
   <body>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "flow-android-build-kit",
+  "short_name": "flow",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0a7bff",
+  "icons": [
+    {
+      "src": "/placeholder.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/placeholder.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,7 @@
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', () => {
+  self.clients.claim();
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,3 +3,11 @@ import App from './App.tsx'
 import './index.css'
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/sw.js')
+      .catch((err) => console.error('SW registration failed', err))
+  })
+}


### PR DESCRIPTION
## Summary
- enable web app installation on Android devices by linking a manifest and setting theme color
- register a simple service worker and provide manifest config

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: vite not found - dependencies unresolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a59364f2d4832dab961535e5245b87